### PR TITLE
Containerization support

### DIFF
--- a/2d_cnn/deploy_config.sh
+++ b/2d_cnn/deploy_config.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+srcdir=$(dirname ${BASH_SOURCE[0]})
+config_file=$1
+cp "${srcdir}/config.yaml" $(pwd)/"${config_file}"

--- a/2d_cnn/deploy_local_2D_container.sh
+++ b/2d_cnn/deploy_local_2D_container.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+srcdir=$(dirname ${BASH_SOURCE[0]})
+config_file=$1
+export CUDA_VISIBLE_DEVICES=
+for i in $(seq 1 1 $(nvidia-smi --list-gpus | wc -l))
+do
+   if [ $i -eq 1 ]
+   then
+      export CUDA_VISIBLE_DEVICES=$(expr $i - 1)
+   else
+      export CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES,$(expr $i - 1)
+   fi
+done
+echo $CUDA_VISIBLE_DEVICES
+
+snakemake \
+    --snakefile "${srcdir}/snakefile.py" \
+    --config config="${config_file}" \
+    --forceall \
+    --printshellcmds \
+    --cores $(nvidia-smi --list-gpus | wc -l) \
+    --resources gpu=$(nvidia-smi --list-gpus | wc -l)

--- a/3d_cnn/deploy_config.sh
+++ b/3d_cnn/deploy_config.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+srcdir=$(dirname ${BASH_SOURCE[0]})
+config_file=$1
+cp "${srcdir}/config.yaml" $(pwd)/"${config_file}"

--- a/3d_cnn/deploy_local_3D_container.sh
+++ b/3d_cnn/deploy_local_3D_container.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+export srcdir="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+config_file=$1
+export CUDA_VISIBLE_DEVICES=
+for i in $(seq 1 1 $(nvidia-smi --list-gpus | wc -l))
+do
+   if [ $i -eq 1 ]
+   then
+      export CUDA_VISIBLE_DEVICES=$(expr $i - 1)
+   else
+      export CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES,$(expr $i - 1)
+   fi
+done
+echo $CUDA_VISIBLE_DEVICES
+export PYTHONPATH=${srcdir}/src
+echo PYTHONPATH=$PYTHONPATH
+
+snakemake \
+    --snakefile "${srcdir}/snakefile" \
+    --config config="${config_file}" gpu=$CUDA_VISIBLE_DEVICES \
+    --printshellcmds \
+    --cores $(nvidia-smi --list-gpus | wc -l) \
+    --resources gpu=$(nvidia-smi --list-gpus | wc -l)

--- a/3d_cnn/environment.yaml
+++ b/3d_cnn/environment.yaml
@@ -25,3 +25,4 @@ dependencies:
   - cudatoolkit=11.6
   - tensorboardx
   - crc32c
+  - snakemake

--- a/3d_cnn/environment.yaml
+++ b/3d_cnn/environment.yaml
@@ -25,4 +25,4 @@ dependencies:
   - cudatoolkit=11.6
   - tensorboardx
   - crc32c
-  - snakemake
+  - snakemake==5.13.0

--- a/3d_cnn/environment.yaml
+++ b/3d_cnn/environment.yaml
@@ -1,25 +1,27 @@
 name: 3d-unet
 channels:
+  - pytorch
   - bioconda
-  - anaconda
   - conda-forge
+  - anaconda
   - default
 dependencies:
   - python=3.7
   - jupyter
   - imageio
-  - pytorch
-  - torchvision
   - scikit-learn
   - scikit-image
   - scipy
   - numpy
-  - tensorboardX
   - tqdm
   - pandas
   - pyaml
   - pip
-  - pip:
-      - h5py==2.10.0
-      - mrcfile==1.1.2
-      - monai
+  - h5py==2.10.0
+  - mrcfile==1.1.2
+  - monai
+  - pytorch==1.12.1
+  - torchvision==0.13.1
+  - cudatoolkit=11.6
+  - tensorboardx
+  - crc32c

--- a/Dockerfile-2d_cnn
+++ b/Dockerfile-2d_cnn
@@ -1,0 +1,25 @@
+FROM nvidia/cuda:10.0-devel-ubuntu18.04
+
+WORKDIR /app/DeePiCt
+COPY . .
+
+# Install necessary packages
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt-get update -y && apt-get install -y dialog apt-utils && \
+    apt-get install -y build-essential git wget software-properties-common && \
+    apt-get update && rm -rf /var/lib/apt/lists/*
+
+# Install miniconda
+ENV PATH="/usr/local/miniconda3/bin:${PATH}"
+ARG PATH="/usr/local/miniconda3/bin:${PATH}"
+RUN cd /tmp  \
+    && wget \
+    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O Miniconda3.sh\
+    && bash Miniconda3.sh -b -p /usr/local/miniconda3 \
+    && rm -f Miniconda3.sh
+
+
+# Create environment
+RUN conda init bash && \
+    conda install -c conda-forge mamba --yes && \
+    mamba env create -f /app/DeePiCt/2d_cnn/envs/keras-env.yaml

--- a/Dockerfile-2d_cnn
+++ b/Dockerfile-2d_cnn
@@ -1,7 +1,8 @@
 FROM nvidia/cuda:10.0-devel-ubuntu18.04
 
+COPY DeePiCt /app/DeePiCt
+COPY deploy_local_2D_container.sh /app/DeePiCt/2d_cnn
 WORKDIR /app/DeePiCt
-COPY . .
 
 # Install necessary packages
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
@@ -23,3 +24,10 @@ RUN cd /tmp  \
 RUN conda init bash && \
     conda install -c conda-forge mamba --yes && \
     mamba env create -f /app/DeePiCt/2d_cnn/envs/keras-env.yaml
+
+RUN cd 2d_cnn && \
+    ln -s deploy_local_2D_container.sh deepict2D && \
+    ln -s deploy_config.sh deepict2D_config
+
+ENV PATH="${PATH}:/app/DeePiCt/2d_cnn"
+ARG PATH="${PATH}:/app/DeePiCt/2d_cnn"

--- a/Dockerfile-3d_cnn
+++ b/Dockerfile-3d_cnn
@@ -1,0 +1,25 @@
+FROM nvidia/cuda:11.6.2-devel-ubuntu20.04
+
+WORKDIR /app/DeePiCt
+COPY . .
+
+# Install necessary packages
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt-get update -y && apt-get install -y dialog apt-utils && \
+    apt-get install -y build-essential git wget software-properties-common && \
+    apt-get update && rm -rf /var/lib/apt/lists/*
+
+# Install miniconda
+ENV PATH="/usr/local/miniconda3/bin:${PATH}"
+ARG PATH="/usr/local/miniconda3/bin:${PATH}"
+RUN cd /tmp  \
+    && wget \
+    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O Miniconda3.sh\
+    && bash Miniconda3.sh -b -p /usr/local/miniconda3 \
+    && rm -f Miniconda3.sh
+
+
+# Create environment
+RUN conda init bash && \
+    conda install -c conda-forge mamba --yes && \
+    mamba env create -f /app/DeePiCt/3d_cnn/environment.yaml \

--- a/Dockerfile-3d_cnn
+++ b/Dockerfile-3d_cnn
@@ -22,4 +22,4 @@ RUN cd /tmp  \
 # Create environment
 RUN conda init bash && \
     conda install -c conda-forge mamba --yes && \
-    mamba env create -f /app/DeePiCt/3d_cnn/environment.yaml \
+    mamba env create -f /app/DeePiCt/3d_cnn/environment.yaml

--- a/Dockerfile-3d_cnn
+++ b/Dockerfile-3d_cnn
@@ -1,7 +1,10 @@
 FROM nvidia/cuda:11.6.2-devel-ubuntu20.04
 
+COPY DeePiCt /app/DeePiCt
+COPY environment.yaml /app/DeePiCt/3d_cnn
+COPY deploy_config.sh /app/DeePiCt/3d_cnn
+COPY deploy_local_3D_container.sh /app/DeePiCt/3d_cnn
 WORKDIR /app/DeePiCt
-COPY . .
 
 # Install necessary packages
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
@@ -23,3 +26,10 @@ RUN cd /tmp  \
 RUN conda init bash && \
     conda install -c conda-forge mamba --yes && \
     mamba env create -f /app/DeePiCt/3d_cnn/environment.yaml
+
+RUN cd 3d_cnn && \
+    ln -s deploy_local_3D_container.sh deepict3D && \
+    ln -s deploy_config.sh deepict3D_config
+
+ENV PATH="${PATH}:/app/DeePiCt/3d_cnn"
+ARG PATH="${PATH}:/app/DeePiCt/3d_cnn"


### PR DESCRIPTION
This pull request contains 2 Dockerfile files to construct 2 Docker images. One that will work for the 2d_cnn scripts using Ubuntu 18.04 and CUDA 10.0 and another for the 3d_cnn, spectrum filter and addtional_scripts scripts using Ubuntu 20.04 and CUDA 11.6. The reason I am using separate images is because the 3d_cnn sripts were written recently (within 2022) with the most up to date pytorch version at the time being pytorch 1.12 (which is only available for CUDA 11.6, 11.3 and 10.2). To also accommodate the installation of pytorch from the recommended conda channel (-c pytorch as you can see [here](https://pytorch.org/get-started/previous-versions/#v1121) ) I properly ammended the environment.yml file in the 3d_cnn directory. I also include some deploy_*.sh files that help with the proper execution of Docker images.

For the Docker image regarding the 2d_cnn scripts, it can be build as such:
```
cd DeePicT
docker build . -f Dockerfile-2d_cnn -t deepict:v1.0.1-2d-cnn
```
and run like this (<data_directory> has to be replaced appropriately):
```
docker run --gpus all -v <data_directory>:/mnt --workdir=/mnt -it --rm deepict:v1.0.1-2d-cnn
```
Within the container first run:
```
source activate snakemake-keras
```
Then you may use:
```
deepict2D_config <template_config_name>.yaml
```
To create a template config file named <sample_config_name>.yaml in the present working directory.
And after modifying it you may run:
```
deepict2D <template_config_name>.yaml
```
Which is similar on doing `bash 2d_cnn/deploy_local.sh <template_config_name>.yaml`

For the Docker image regarding the 3d_cnn scripts, it can be build as such:
```
cd DeePicT
docker build . -f Dockerfile-3d_cnn -t deepict:v1.0.1-3d-cnn
```
and run like this (<data_directory> has to be replaced appropriately):
```
docker run --gpus all -v <data_directory>:/mnt --workdir=/mnt -it --rm deepict:v1.0.1-3d-cnn
```
Within the container first run:
```
source activate 3d-unet
```
Then you may use:
```
deepict3D_config <template_config_name>.yaml
```
To create a template config file named <sample_config_name>.yaml in the present working directory.
And after modifying it you may run:
```
deepict3D <template_config_name>.yaml
```
Which is similar on doing `bash 3d_cnn/deploy_local.sh <template_config_name>.yaml`